### PR TITLE
[Design] #4 카카오맵 API 애니메이션 및 디자인 전체 수정

### DIFF
--- a/src/pages/booth/BoothPage.jsx
+++ b/src/pages/booth/BoothPage.jsx
@@ -46,6 +46,8 @@ export const BoothPage = () => {
   // 마킹 용 배열
   const mapRef = useRef(null);
   const markersRef = useRef([]);
+  const mapSizingRef = useRef(null);
+  const boothListRef = useRef(null);
 
   const toggleDropdown = (type) => {
     setIsDropdownOpen((prevState) => ({
@@ -179,8 +181,8 @@ export const BoothPage = () => {
 
     if (highlightedBooth && mapRef.current) {
       // 선택된 부스의 위치 좌표로 맵의 중심 이동
-      const newCenter = new window.kakao.maps.LatLng(highlightedBooth.latitude-0.0017, highlightedBooth.longitude);
-      mapRef.current.setCenter(newCenter);
+      const newCenter = new window.kakao.maps.LatLng(highlightedBooth.latitude, highlightedBooth.longitude);
+      mapRef.current.panTo(newCenter);
     }
   
     // 선택된 부스가 있을 경우, 해당 마커만 업데이트
@@ -215,14 +217,36 @@ export const BoothPage = () => {
     }
   }, [highlightedBooth]);
 
+  useEffect(() => {
+    if (mapSizingRef.current && boothListRef.current) {
+      const boothListHeight = isBoothListOpen ? 520 : 180;
+      const mapHeight = `calc(100vh - ${boothListHeight}px)`;
+      mapSizingRef.current.style.height = mapHeight;
+
+      if (mapRef.current) {
+        mapRef.current.relayout();
+
+        setTimeout(() => {
+          window.kakao.maps.event.trigger(mapRef.current, 'resize');
+
+          if (highlightedBooth) {
+            const newCenter = new window.kakao.maps.LatLng(highlightedBooth.latitude, highlightedBooth.longitude);
+            mapRef.current.panTo(newCenter);
+          }
+        }, 200);
+      }
+    }
+  }, [isBoothListOpen, selectBooth, highlightedBooth]);
+  
+
   return (
     <>
       <S.MainWrapper>
-        <TopBar openModal={openModal}/>
         {/* 상단 날짜 선택 버튼 */}
+        <TopBar openModal={openModal}/>
 
         {/* 카카오맵 자리 */}
-        <S.MapPlaceholder id='map'>
+        <S.MapPlaceholder ref={mapSizingRef} $isBoothListOpen={isBoothListOpen} id='map'>
           <S.Header>
             <S.DateSelector>
               <S.DateButton
@@ -243,7 +267,7 @@ export const BoothPage = () => {
 
 
         {/* 부스 리스트 */}
-        <S.BoothListWrapper $isOpen={isBoothListOpen}>
+        <S.BoothListWrapper ref={boothListRef} $isOpen={isBoothListOpen}>
           <S.BoothListHeader onClick={toggleBoothList}>
             <S.Arrow>{isBoothListOpen ? <RxDoubleArrowDown /> : <RxDoubleArrowUp />}</S.Arrow>
           </S.BoothListHeader>

--- a/src/pages/booth/Styled.js
+++ b/src/pages/booth/Styled.js
@@ -98,12 +98,11 @@ export const DateButton = styled.div`
 // 카카오맵이 들어갈 자리
 export const MapPlaceholder = styled.div`
   width: 100%;
-  height: 100%;
+  height: ${({ $isBoothListOpen }) => ($isBoothListOpen ? 'calc(100vh - 520px)' : 'calc(100vh - 180px)')};
   background-color: #e0e0e0;
   display: flex;
   justify-content: center;
   color: #666;
-  margin-bottom: 20px;
 `;
 
 // 부스 리스트와 필터가 들어가는 Wrapper
@@ -115,7 +114,7 @@ export const BoothListWrapper = styled.div`
   bottom: ${({ $isOpen }) => ($isOpen ? '0' : '-140px')};
   width: 100%;
   max-width: 540px;
-  height: ${({ $isOpen }) => ($isOpen ? '50%' : '200px')};
+  height: ${({ $isOpen }) => ($isOpen ? '400px' : '200px')};
   background-color: inherit;
   transition: bottom 0.5s ease, height 0.5s ease;
   z-index: 10;


### PR DESCRIPTION
## 🔍 What is the PR?

- 기존 딱딱하게 움직였던 애니메이션 수정.
- 첫번째 스샷을 보면. 위경도를 강제로 화면상 이동시켜 매끄럽지 못하게 움직였고, 확대 level에 따라 위치가 다르게 떴었습니다. 이를 수정해서 카카오 맵의 width와 height를 고려하여 중심을 맞춰서 유동적인 화면 구현했습니다.

## 📸 Screenshot

<img width="700" alt="image" src="https://github.com/user-attachments/assets/4b946a4e-8e3f-4ac5-8941-ee2ec30083a9">

변경 후
<img width="390" alt="image" src="https://github.com/user-attachments/assets/81f0b323-1a55-4c7e-b5c2-c5fcf9890cc0">
<img width="390" alt="image" src="https://github.com/user-attachments/assets/46c6f507-fe5c-4577-918d-80a41359cde3">


## 📍 PR Point

카카오맵 중심을 찾아 아이콘을 클릭시 무조건 카카오맵 중심으로 이동하게 했습니다!
내가 카카오맵 resize시에 다른 애니메이션이나 panto()와 충돌이 계속 나서
setTimeout으로 지연시키고 relayout으로 레이아웃자체를 재 호출하는 방식으로 해결했습니다.
보다 매끄러운 화면 구현에 성공했습니다.
특정 부스 선택하고 modal을 내렸을 경우에도 매끄럽게 이동합니다.

## 📢 Notices

벡엔드랑 API 연결
현 위치 기반 넣기

빠르게 작성해보겠습니다.

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

#4 
